### PR TITLE
php 8 and phpunit 9.5 Support

### DIFF
--- a/src/Amqp/SendAndReceiveTimestampAsIntegerSpec.php
+++ b/src/Amqp/SendAndReceiveTimestampAsIntegerSpec.php
@@ -17,7 +17,7 @@ abstract class SendAndReceiveTimestampAsIntegerSpec extends TestCase
      */
     private $context;
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if ($this->context) {
             $this->context->close();

--- a/src/Amqp/SubscriptionConsumerAddConsumerTagOnSubscribeSpec.php
+++ b/src/Amqp/SubscriptionConsumerAddConsumerTagOnSubscribeSpec.php
@@ -16,7 +16,7 @@ abstract class SubscriptionConsumerAddConsumerTagOnSubscribeSpec extends TestCas
      */
     private $context;
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if ($this->context) {
             $this->context->close();

--- a/src/Amqp/SubscriptionConsumerPreFetchCountSpec.php
+++ b/src/Amqp/SubscriptionConsumerPreFetchCountSpec.php
@@ -16,7 +16,7 @@ abstract class SubscriptionConsumerPreFetchCountSpec extends TestCase
      */
     private $context;
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if ($this->context) {
             $this->context->close();

--- a/src/Amqp/SubscriptionConsumerRemoveConsumerTagOnUnsubscribeSpec.php
+++ b/src/Amqp/SubscriptionConsumerRemoveConsumerTagOnUnsubscribeSpec.php
@@ -16,7 +16,7 @@ abstract class SubscriptionConsumerRemoveConsumerTagOnUnsubscribeSpec extends Te
      */
     private $context;
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if ($this->context) {
             $this->context->close();

--- a/src/RequeueMessageSpec.php
+++ b/src/RequeueMessageSpec.php
@@ -18,7 +18,7 @@ abstract class RequeueMessageSpec extends TestCase
      */
     private $context;
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if ($this->context) {
             $this->context->close();

--- a/src/SendAndReceiveDelayedMessageFromQueueSpec.php
+++ b/src/SendAndReceiveDelayedMessageFromQueueSpec.php
@@ -17,7 +17,7 @@ abstract class SendAndReceiveDelayedMessageFromQueueSpec extends TestCase
      */
     private $context;
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if ($this->context) {
             $this->context->close();

--- a/src/SendAndReceivePriorityMessagesFromQueueSpec.php
+++ b/src/SendAndReceivePriorityMessagesFromQueueSpec.php
@@ -17,7 +17,7 @@ abstract class SendAndReceivePriorityMessagesFromQueueSpec extends TestCase
      */
     private $context;
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if ($this->context) {
             $this->context->close();

--- a/src/SendAndReceiveTimeToLiveMessagesFromQueueSpec.php
+++ b/src/SendAndReceiveTimeToLiveMessagesFromQueueSpec.php
@@ -17,7 +17,7 @@ abstract class SendAndReceiveTimeToLiveMessagesFromQueueSpec extends TestCase
      */
     private $context;
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if ($this->context) {
             $this->context->close();

--- a/src/SendToAndReceiveFromQueueSpec.php
+++ b/src/SendToAndReceiveFromQueueSpec.php
@@ -17,7 +17,7 @@ abstract class SendToAndReceiveFromQueueSpec extends TestCase
      */
     private $context;
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if ($this->context) {
             $this->context->close();

--- a/src/SendToAndReceiveFromTopicSpec.php
+++ b/src/SendToAndReceiveFromTopicSpec.php
@@ -17,7 +17,7 @@ abstract class SendToAndReceiveFromTopicSpec extends TestCase
      */
     private $context;
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if ($this->context) {
             $this->context->close();

--- a/src/SendToAndReceiveNoWaitFromQueueSpec.php
+++ b/src/SendToAndReceiveNoWaitFromQueueSpec.php
@@ -17,7 +17,7 @@ abstract class SendToAndReceiveNoWaitFromQueueSpec extends TestCase
      */
     private $context;
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if ($this->context) {
             $this->context->close();

--- a/src/SendToAndReceiveNoWaitFromTopicSpec.php
+++ b/src/SendToAndReceiveNoWaitFromTopicSpec.php
@@ -17,7 +17,7 @@ abstract class SendToAndReceiveNoWaitFromTopicSpec extends TestCase
      */
     private $context;
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if ($this->context) {
             $this->context->close();

--- a/src/SendToTopicAndReceiveFromQueueSpec.php
+++ b/src/SendToTopicAndReceiveFromQueueSpec.php
@@ -18,7 +18,7 @@ abstract class SendToTopicAndReceiveFromQueueSpec extends TestCase
      */
     private $context;
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if ($this->context) {
             $this->context->close();

--- a/src/SendToTopicAndReceiveNoWaitFromQueueSpec.php
+++ b/src/SendToTopicAndReceiveNoWaitFromQueueSpec.php
@@ -18,7 +18,7 @@ abstract class SendToTopicAndReceiveNoWaitFromQueueSpec extends TestCase
      */
     private $context;
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if ($this->context) {
             $this->context->close();

--- a/src/SubscriptionConsumerConsumeFromAllSubscribedQueuesSpec.php
+++ b/src/SubscriptionConsumerConsumeFromAllSubscribedQueuesSpec.php
@@ -18,7 +18,7 @@ abstract class SubscriptionConsumerConsumeFromAllSubscribedQueuesSpec extends Te
      */
     private $context;
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if ($this->context) {
             $this->context->close();

--- a/src/SubscriptionConsumerConsumeUntilUnsubscribedSpec.php
+++ b/src/SubscriptionConsumerConsumeUntilUnsubscribedSpec.php
@@ -24,7 +24,7 @@ abstract class SubscriptionConsumerConsumeUntilUnsubscribedSpec extends TestCase
      */
     protected $subscriptionConsumer;
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if ($this->context) {
             $this->context->close();

--- a/src/SubscriptionConsumerStopOnFalseSpec.php
+++ b/src/SubscriptionConsumerStopOnFalseSpec.php
@@ -18,7 +18,7 @@ abstract class SubscriptionConsumerStopOnFalseSpec extends TestCase
      */
     private $context;
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if ($this->context) {
             $this->context->close();


### PR DESCRIPTION
I just updated return typehints of tearDown methods so they now compatible with phpunit 9.5 which allows to use this package on projects with php 8 onboard as well as needed to proceed with enqueue update: https://github.com/php-enqueue/enqueue-dev/pull/1121 